### PR TITLE
Rename fission-suite to fission-codes

### DIFF
--- a/appendix/troubleshooting.md
+++ b/appendix/troubleshooting.md
@@ -29,17 +29,17 @@ sudo sysctl fs.inotify.max_user_watches=1048576
 We've had some hiccups with our brew formula recently. To re-install / reset brew, run the following:
 
 ```text
-brew untap fission-suite/fission
+brew untap fission-codes/fission
 ```
 
 Now re-run the [installation instructions](https://guide.fission.codes/installation#macos), copied here for convenience:
 
 ```text
-brew tap fission-suite/fission
+brew tap fission-codes/fission
 brew install fission-cli
 ```
 
-This is related to [issue \#37](https://github.com/fission-suite/cli/issues/37).
+This is related to [issue \#37](https://github.com/fission-codes/cli/issues/37).
 
 ## DEBUG mode for fission cli
 

--- a/apps/installation.md
+++ b/apps/installation.md
@@ -83,16 +83,16 @@ For Windows users, we currently recommend using the Windows Subsystem for Linux 
 We have a brew recipe to get you up and running quickly on MacOS:
 
 ```bash
-$ brew tap fission-suite/fission
+$ brew tap fission-codes/fission
 $ brew install fission-cli
 ```
 
 #### Linux \(and manual MacOS\)
 
-Head over to our [releases](https://github.com/fission-suite/cli/releases) page on Github and download the latest release for your operating system.
+Head over to our [releases](https://github.com/fission-codes/cli/releases) page on Github and download the latest release for your operating system.
 
 {% hint style="warning" %}
-Note: Ubuntu 19+ is currently not supported due to [a build issue \#51](https://github.com/fission-suite/cli/issues/51)
+Note: Ubuntu 19+ is currently not supported due to [a build issue \#51](https://github.com/fission-codes/cli/issues/51)
 {% endhint %}
 
 Unzip the file and move the file to your PATH:

--- a/developers/heroku.md
+++ b/developers/heroku.md
@@ -19,7 +19,7 @@ If you create the add-on through the Heroku dashboard, you can find your API cre
 These can also be used in your local environment by creating an `.env` file.
 
 {% hint style="info" %}
-The Heroku Add-on uses the Web API, appropriate for server side apps written in any language that Heroku supports. You can browse the live docs of the Fission Web API at [runfission.com/docs](https://runfission.com/docs), or look at our [Github repo](https://github.com/fission-suite) to find a client SDK for your programming language.
+The Heroku Add-on uses the Web API, appropriate for server side apps written in any language that Heroku supports. You can browse the live docs of the Fission Web API at [runfission.com/docs](https://runfission.com/docs), or look at our [Github repo](https://github.com/fission-codes) to find a client SDK for your programming language.
 {% endhint %}
 
 ### Deploy to Heroku
@@ -32,7 +32,7 @@ This means adding an `app.json` file and a few other settings that tell Heroku w
 
 #### Ghost Blogging on Heroku with IPFS
 
-We built an [IPFS Storage Adapter for the Ghost blogging platform](https://github.com/fission-suite/ghost-storage-adapter-ipfs), and bundled it together with Deploy to Heroku and the Fission Heroku Add On. You can get started on the hobby tier by clicking the Deploy to Heroku button on Github:
+We built an [IPFS Storage Adapter for the Ghost blogging platform](https://github.com/fission-codes/ghost-storage-adapter-ipfs), and bundled it together with Deploy to Heroku and the Fission Heroku Add On. You can get started on the hobby tier by clicking the Deploy to Heroku button on Github:
 
-* [https://github.com/fission-suite/heroku-ipfs-ghost](https://github.com/fission-suite/heroku-ipfs-ghost)
+* [https://github.com/fission-codes/heroku-ipfs-ghost](https://github.com/fission-codes/heroku-ipfs-ghost)
 

--- a/developers/resources.md
+++ b/developers/resources.md
@@ -4,11 +4,11 @@ Here are some additional resources to help you understand the wider Fission ecos
 
 * [Fission Web API docs through Swagger](https://runfission.com/docs/)
   * Use this if you want to make REST calls directly to our API. 
-* [Fission JavaScript client](https://github.com/fission-suite/typescript-client) 
+* [Fission JavaScript client](https://github.com/fission-codes/typescript-client) 
   * Client library for the Fission Web API
   * Use this if you want to add IPFS support to your app through HTTP
   * Compatible with JavaScript and TypeScript
-* [Fission Github](https://github.com/fission-suite)
+* [Fission Github](https://github.com/fission-codes)
   * See all of our projects, the latest releases, features that we're working on, and known issues.
 * [Fission blog](https://blog.fission.codes/)
   * Stay up to date with what we're working on as well as our thoughts on decentralization, open-source, and more!

--- a/developers/web-api.md
+++ b/developers/web-api.md
@@ -17,10 +17,10 @@ For example:
 $ curl https://runfission.com/ipfs/QmWATWQ7fVPP2EFGu71UkfnqhYXDYH566qy47CnJDgvs8u
 ```
 
-If you want to do this programmatically, use your favorite REST client or the [Fission TypeScript Client](https://github.com/fission-suite/typescript-client)
+If you want to do this programmatically, use your favorite REST client or the [Fission TypeScript Client](https://github.com/fission-codes/typescript-client)
 
 ```javascript
-import { content } from '@fission-suite/client'
+import { content } from '@fission-codes/client'
 const helloWorld = await content("QmWATWQ7fVPP2EFGu71UkfnqhYXDYH566qy47CnJDgvs8u")
 ```
 
@@ -53,10 +53,10 @@ $ curl -i \
      https://runfission.com/ipfs
 ```
 
-If you want to do this programmatically, use your favorite REST client or the [Fission TypeScript Client](https://github.com/fission-suite/typescript-client)
+If you want to do this programmatically, use your favorite REST client or the [Fission TypeScript Client](https://github.com/fission-codes/typescript-client)
 
 ```javascript
-import { add } from '@fission-suite/client'
+import { add } from '@fission-codes/client'
 const auth = { username: "username", password: "password" }
 const content = {
   key1: 123,
@@ -79,10 +79,10 @@ curl -i \
      https://runfission.com/ipfs/QmWATWQ7fVPP2EFGu71UkfnqhYXDYH566qy47CnJDgvs8u
 ```
 
-If you want to do this programmatically, use your favorite REST client or the [Fission TypeScript Client](https://github.com/fission-suite/typescript-client)
+If you want to do this programmatically, use your favorite REST client or the [Fission TypeScript Client](https://github.com/fission-codes/typescript-client)
 
 ```javascript
-import { pin } from '@fission-suite/client'
+import { pin } from '@fission-codes/client'
 const auth = { username: "username", password: "password" }
 await pin("QmWATWQ7fVPP2EFGu71UkfnqhYXDYH566qy47CnJDgvs8u", auth)
 ```


### PR DESCRIPTION
Note that the homebrew and npm orgs needs to change first.